### PR TITLE
Fixed parametrization of sweeps

### DIFF
--- a/arbok_driver/sweep.py
+++ b/arbok_driver/sweep.py
@@ -303,7 +303,7 @@ class Sweep:
         step *= 0.999
         if param.var_type == int:
             start, stop = int(sweep_array[0]), int(sweep_array[-1] + step)
-            step = int(step)
+            step = round(step)
 
         ### This can probably done more elegantly
         length_of_array = len(np.arange(start, stop, step))


### PR DESCRIPTION
When parameterizing an array of integers there can be a mismatch between between the array generated from start stop and step compared to the input array. Changes here try to compensate that