### PR TITLE
Parameterize readouts

### DIFF
--- a/arbok_driver/abstract_readout.py
+++ b/arbok_driver/abstract_readout.py
@@ -17,7 +17,8 @@ class AbstractReadout(ABC):
         name: str,
         sequence: ReadSequence,
         attr_name: str,
-        save_results: bool = True
+        save_results: bool = True,
+        params: dict = {}
     ):
         """
         Constructor method of `AbstractReadout`
@@ -28,12 +29,17 @@ class AbstractReadout(ABC):
             attr_name (str): Name of the attribute as which the readout will be
                 added in the signal
             save_results (bool, optional): Whether to save the results
+            params (dict, optional): Parameters to be added to the read sequence
         """
         self.name = name
         self.sequence = sequence
         self.attr_name = attr_name
         self.save_results = save_results
         self.observables = {}
+
+        ### Parameters are added to the sequence with the readout prefix
+        params = [f'{self.name}_{key}' for key in params]
+        self.sequence.add_qc_params_from_config(params)
 
     def qua_declare_variables(self):
         """Declares all necessary qua variables for readout"""

--- a/arbok_driver/generic_tunig_interface.py
+++ b/arbok_driver/generic_tunig_interface.py
@@ -105,7 +105,7 @@ class GenericTuningInterface:
         given host ip.
         """
         self.program.connect_opx(host_ip = host_ip)
-        self.qua_program = self.program.get_qua_program()
+        self.qua_program = self.sequence.get_qua_program()
         self.program.run(self.qua_program)
 
     def run_parameter_set(

--- a/arbok_driver/gettable_parameter.py
+++ b/arbok_driver/gettable_parameter.py
@@ -107,10 +107,11 @@ class GettableParameter(ParameterWithSetpoints):
         total_results = "Total results: ..."
         t0 = time.time()
         try:
+            # self.qm_job.resume()
             while batch_count < self.batch_size or not self.qm_job.is_paused():
                 logging.debug(
-                    "Waiting for buffer to fill (%s/%s)",
-                    batch_count, self.batch_size
+                    "Waiting for buffer to fill (%s/%s), %s",
+                    batch_count, self.batch_size, self.qm_job.is_paused()
                     )
                 shot_count_result = self.batch_counter.fetch_all()
                 if shot_count_result is not None:

--- a/arbok_driver/gettable_parameter.py
+++ b/arbok_driver/gettable_parameter.py
@@ -1,8 +1,7 @@
 """ Module containing GettableParameter class """
 
-import warnings
 import time
-import logging as lg
+import logging
 import numpy as np
 import matplotlib.pyplot as plt
 from qcodes.parameters import ParameterWithSetpoints
@@ -61,6 +60,7 @@ class GettableParameter(ParameterWithSetpoints):
         On its first call, the gettables attributes get configured regarding
         the given measurement and the underlying hardware.
         """
+        logging.debug("GettableParameter %s get_raw called", self.name)
         ### Setup is called on first get
         if self.buffer is None:
             self._set_up_gettable_from_program()
@@ -108,6 +108,10 @@ class GettableParameter(ParameterWithSetpoints):
         t0 = time.time()
         try:
             while batch_count < self.batch_size or not self.qm_job.is_paused():
+                logging.debug(
+                    "Waiting for buffer to fill (%s/%s)",
+                    batch_count, self.batch_size
+                    )
                 shot_count_result = self.batch_counter.fetch_all()
                 if shot_count_result is not None:
                     batch_count = shot_count_result[0]

--- a/arbok_driver/measurement_helpers.py
+++ b/arbok_driver/measurement_helpers.py
@@ -42,6 +42,7 @@ def create_measurement_loop(
     Returns:
         qcodes.Dataset: Dataset of the measurement
     """
+    logging.debug("Creating measurement loop")
     sweep_lengths = [len(next(iter(dic.values()))) for dic in sweep_list]
     nr_sweep_list_points = np.prod(sweep_lengths)
     def decorator(func):

--- a/arbok_driver/parameter_types.py
+++ b/arbok_driver/parameter_types.py
@@ -72,8 +72,11 @@ class List(SequenceParameter):
     """ Default: Strings """
     sweep_validator = Sequence()
 
-class Int(Time):
-    unit = '#'
+class Int(SequenceParameter):
+    qua_type = int
+    """ Default: int """
+    validator = Ints()
+    sweep_validator = MultiTypeOr(Numbers(), Arrays(valid_types = [int]))
 
 class Radian(SequenceParameter):
     unit = 'pi'

--- a/arbok_driver/read_sequence.py
+++ b/arbok_driver/read_sequence.py
@@ -157,7 +157,6 @@ class ReadSequence(SubSequence):
                     sequence = self,
                     save_results = save_results,
                     params = params,
-                    **readout_conf["args"],
                 )
                 readout_group[readout_name] = abstract_readout
                 self._abstract_readouts[readout_name] = abstract_readout

--- a/arbok_driver/read_sequence.py
+++ b/arbok_driver/read_sequence.py
@@ -146,11 +146,17 @@ class ReadSequence(SubSequence):
                     save_results = readout_conf["save_results"]
                 else:
                     save_results = True
+                if "params" in readout_conf:
+                    params = readout_conf["params"]
+                else:
+                    params = {}
+
                 abstract_readout = ReadoutClass(
                     name = readout_name,
                     attr_name = readout_conf["name"],
                     sequence = self,
                     save_results = save_results,
+                    params = params,
                     **readout_conf["args"],
                 )
                 readout_group[readout_name] = abstract_readout

--- a/arbok_driver/sequence.py
+++ b/arbok_driver/sequence.py
@@ -309,7 +309,7 @@ class Sequence(SequenceBase):
         ### An infinite loop starting with a pause is defined to sync the
         ### client with the QMs
         with qua.infinite_loop_():
-            if not simulate or not self.no_pause:
+            if not simulate:
                 qua.pause()
 
             ### Check requirements are set to True if the sequence is simulated

--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -508,5 +508,6 @@ class SequenceBase(InstrumentModule):
         """
         for param_name, param in self.parameters.items():
             if param.unit == unit:
+                print(f"Setting param {param_name} to {value}")
                 logging.debug("Setting param %s to %s", param_name, value)
                 param(value)


### PR DESCRIPTION
Overworked the way (abstract)-readouts are configured.

Instead of a list of attributes, a parameter config is being passed to the constructor. The syntax is identical to param configs for sequences. With this, parameters on the respective can be established from the abstract readout. Therefore properties of readouts can be altered/ sweeped in real time.

This PR will break all previously merged readout configurations! Only merge/ pull after confirmation with users