### PR TITLE
Including sequence type in configs

### DIFF
--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -584,19 +584,19 @@ class Measurement(SequenceBase):
     def add_subsequences_from_dict(
             self,
             subsequence_dict: dict,
-            insert_sequences_into_name_space: dict = None) -> None:
+            namespace_to_add_to: dict = None) -> None:
         """
         Adds subsequences to the sequence from a given dictionary
 
         Args:
             subsequence_dict (dict): Dictionary containing the subsequences
-            insert_sequences_into_name_space (dict): Name space to insert the
+            namespace_to_add_to (dict): Name space to insert the
                 subsequence into (e.g locals(), globals()) defaults to None
         """
         super()._add_subsequences_from_dict(
             default_sequence = SubSequence,
             subsequence_dict = subsequence_dict,
-            insert_sequences_into_name_space = insert_sequences_into_name_space
+            namespace_to_add_to = namespace_to_add_to
         )
 
     def get_qc_measurement(

--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -2,6 +2,7 @@
 import math
 import copy
 import logging
+import types
 from collections import Counter
 
 import numpy as np
@@ -580,41 +581,23 @@ class Measurement(SequenceBase):
         logging.debug('Adding step requirement: %s', requirement)
         self._step_requirements.append(requirement)
 
-    def _add_subsequence(
-        self,
-        name: str,
-        subsequence: SubSequence,
-        sequence_config: dict = None,
-        insert_sequences_into_name_space: dict = None,
-        **kwargs
-        ) -> None:
+    def add_subsequences_from_dict(
+            self,
+            subsequence_dict: dict,
+            insert_sequences_into_name_space: dict = None) -> None:
         """
-        Adds a subsequence to the sequence
-        
+        Adds subsequences to the sequence from a given dictionary
+
         Args:
-            name (str): Name of the subsequence
-            subsequence (SubSequence): Subsequence to be added
-            sequence_config (dict): Config containing all measurement params
+            subsequence_dict (dict): Dictionary containing the subsequences
             insert_sequences_into_name_space (dict): Name space to insert the
                 subsequence into (e.g locals(), globals()) defaults to None
         """
-        if subsequence == 'default':
-            subsequence = SubSequence
-        if not issubclass(subsequence, SubSequence):
-            raise TypeError(
-                "Subsequence must be of type SubSequence or str: 'default'")
-        seq_instance = subsequence(
-            parent = self,
-            name = name,
-            sample = self.sample,
-            sequence_config = sequence_config,
-            **kwargs
-            )
-        setattr(self, name, seq_instance)
-        if insert_sequences_into_name_space is not None:
-            name_space = insert_sequences_into_name_space
-            name_space[name] = seq_instance
-        return seq_instance
+        super()._add_subsequences_from_dict(
+            default_sequence = SubSequence,
+            subsequence_dict = subsequence_dict,
+            insert_sequences_into_name_space = insert_sequences_into_name_space
+        )
 
     def get_qc_measurement(
             self, measurement_name: str) -> qc.dataset.Measurement:

--- a/arbok_driver/sample.py
+++ b/arbok_driver/sample.py
@@ -13,20 +13,27 @@ class Sample():
             self, name: str,
             opx_config: dict,
             divider_config: dict,
-            param_config = None,):
+            param_config = None,
+            default_sequence_configs = None
+            ):
         """
         Constructor class for 'Sample' class.
 
         Args:
             name (str): Name of the used sample
-            config (dict): OPX configuration file for sample
-            self.elements (list): List of all quantum elements
+            opx_config (dict): Configuration dictionary for the OPX
+            divider_config (dict): Configuration dictionary for the divider
+            param_config (dict): Configuration dictionary for the parameters
+                Also known as master config with params available to all subseq.
+            default_sequence_configs (dict): Default sequence configurations
+                Lookup table to find default configs for any subsequences
         """
         self.name = name
         self.config = opx_config
         self.param_config = param_config
         self.divider_config = divider_config
         self.elements = list(self.config['elements'].keys())
+        self.default_sequence_configs = default_sequence_configs
 
     @property
     def master_config_path(self):
@@ -55,7 +62,10 @@ class Sample():
         self._master_config_path = config_path
         mc = get_module('mc', config_path)
         if not hasattr(mc, 'config'):
-            raise AttributeError(f"Dictionary 'config' not found in the file {self._master_config_path}")
+            raise AttributeError(
+                "Dictionary 'config' not found in the file: "
+                f"{self._master_config_path}"
+                )
         self.master_config = mc.config
 
     def reload_master_config(self):

--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -469,7 +469,7 @@ class SequenceBase(InstrumentModule):
         else:
             if sequence_config is not None:
                 warnings.warn(
-                    "Depcrecation Warning: sequence types should not be given as "
+                    "Deprecation Warning: sequence types should not be given as "
                     "arg to 'add_subsequence'. Should be ONLY given in config. "
                     f"{sequence_config['sequence'].__name__} -> "
                     f"{subsequence.__name__}",

--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -473,6 +473,7 @@ class SequenceBase(InstrumentModule):
                     "arg to 'add_subsequence'. Should be ONLY given in config. "
                     f"{sequence_config['sequence'].__name__} -> "
                     f"{subsequence.__name__}",
+                    category = DeprecationWarning
                     )
         if not issubclass(subsequence, SequenceBase):
             raise TypeError(

--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -454,6 +454,7 @@ class SequenceBase(InstrumentModule):
             namespace_to_add_to (dict): Name space to insert the
                 subsequence into (e.g locals(), globals()) defaults to None
         """
+        given_subsequence = subsequence
         if subsequence is None:
             if sequence_config is None:
                 raise ValueError(
@@ -467,14 +468,16 @@ class SequenceBase(InstrumentModule):
                     "'sequence' key with a subsequence type to configure for."
                     ) from exc
         else:
-            if sequence_config is not None:
-                warnings.warn(
-                    "Deprecation Warning: sequence types should not be given as "
-                    "arg to 'add_subsequence'. Should be ONLY given in config. "
-                    f"{sequence_config['sequence'].__name__} -> "
-                    f"{subsequence.__name__}",
-                    category = DeprecationWarning
-                    )
+            if given_subsequence is not None:
+                if sequence_config is not None and 'sequence' in sequence_config:
+                    warnings.warn(
+                        "Deprecation Warning: sequence types should not be given as "
+                        "arg to 'add_subsequence'. Should be ONLY given in config. "
+                        f"{sequence_config['sequence'].__name__} -> "
+                        f"{subsequence.__name__}",
+                        category = DeprecationWarning
+                        )
+                subsequence = given_subsequence
         if not issubclass(subsequence, SequenceBase):
             raise TypeError(
                 "Subsequence must be of type SubSequence")

--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -2,6 +2,7 @@
 
 import copy
 import types
+import warnings
 from typing import Optional
 import logging
 
@@ -437,9 +438,9 @@ class SequenceBase(InstrumentModule):
     def _add_subsequence(
         self,
         name: str,
-        subsequence: 'SequenceBase',
+        subsequence: 'SequenceBase' = None,
         sequence_config: dict = None,
-        insert_sequences_into_name_space: dict = None,
+        namespace_to_add_to: dict = None,
         **kwargs
         ) -> None:
         """
@@ -449,9 +450,29 @@ class SequenceBase(InstrumentModule):
             name (str): Name of the subsequence
             subsequence (SubSequence): Subsequence to be added
             sequence_config (dict): Config containing all measurement params
-            insert_sequences_into_name_space (dict): Name space to insert the
+            namespace_to_add_to (dict): Name space to insert the
                 subsequence into (e.g locals(), globals()) defaults to None
         """
+        if subsequence is None:
+            if sequence_config is None:
+                raise ValueError(
+                    "Neither a subsequence nor a sequence_config was given. "
+                    )
+            try:
+                subsequence = sequence_config['sequence']
+            except KeyError as exc:
+                raise KeyError(
+                    f"The given config for {self.name} does not contain a "
+                    "'sequence' key with a subsequence type to configure for."
+                    ) from exc
+        else:
+            if sequence_config is not None:
+                warnings.warn(
+                    "Depcrecation Warning: sequence types should not be given as "
+                    "arg to 'add_subsequence'. Should be ONLY given in config. "
+                    f"{sequence_config['sequence'].__name__} -> "
+                    f"{subsequence.__name__}",
+                    )
         if not issubclass(subsequence, SequenceBase):
             raise TypeError(
                 "Subsequence must be of type SubSequence")
@@ -463,8 +484,8 @@ class SequenceBase(InstrumentModule):
             **kwargs
             )
         setattr(self, name, seq_instance)
-        if insert_sequences_into_name_space is not None:
-            name_space = insert_sequences_into_name_space
+        if namespace_to_add_to is not None:
+            name_space = namespace_to_add_to
             name_space[name] = seq_instance
         return seq_instance
 
@@ -472,7 +493,7 @@ class SequenceBase(InstrumentModule):
             self,
             default_sequence,
             subsequence_dict: dict,
-            insert_sequences_into_name_space: dict = None) -> None:
+            namespace_to_add_to: dict = None) -> None:
         """
         Adds subsequences to the sequence from a given dictionary
 
@@ -483,7 +504,7 @@ class SequenceBase(InstrumentModule):
                 cant be directly referenced here but is given from the
                 respective child
             subsequence_dict (dict): Dictionary containing the subsequences
-            insert_sequences_into_name_space (dict): Name space to insert the
+            namespace_to_add_to (dict): Name space to insert the
                 subsequence into (e.g locals(), globals()) defaults to None
                     """
         if type(self) is SequenceBase:
@@ -492,35 +513,60 @@ class SequenceBase(InstrumentModule):
         if isinstance(subsequence_dict, types.SimpleNamespace):
             subsequence_dict = vars(subsequence_dict)
         for name, seq_conf  in subsequence_dict.items():
-            if 'sequence' in seq_conf:
-                subsequence = seq_conf['sequence']
-                if 'config' in seq_conf:
-                    sub_seq_conf = seq_conf['config']
-                    if not isinstance(sub_seq_conf, dict):
-                        raise ValueError(
-                            f"Subsequence config ({name}) must be of type dict,"
-                            f" is {type(sub_seq_conf)}")
-                else:
-                    sub_seq_conf = None
-                if 'kwargs' in seq_conf:
-                    kwargs = seq_conf['kwargs']
-                    if not isinstance(kwargs, dict):
-                        raise ValueError(
-                            f"Kwargs must be of type dict, is {type(kwargs)}")
-                else:
-                    kwargs = {}
-                _ = self._add_subsequence(
-                    name, subsequence, sub_seq_conf,
-                    insert_sequences_into_name_space, **kwargs)
-            else:
+            ### Check whether a subsequence is configured or empty 
+            if all(k not in seq_conf.keys() for k in ['sequence', 'config']):
+                ### If empty SubSequence, create one deeper nesting layer
                 seq_instance = self._add_subsequence(
                     name = name,
                     subsequence = default_sequence,
                     sequence_config = None,
-                    insert_sequences_into_name_space = insert_sequences_into_name_space
+                    namespace_to_add_to = namespace_to_add_to
                     )
                 seq_instance.add_subsequences_from_dict(
-                    seq_conf, insert_sequences_into_name_space)
+                    seq_conf, namespace_to_add_to)
+            else:
+                self._prepare_adding_subsequence(
+                    name, seq_conf, namespace_to_add_to)
+
+    def _prepare_adding_subsequence(
+            self,
+            name: str,
+            seq_conf: dict,
+            namespace_to_add_to: dict = None
+            ) -> None:
+            ### Check if config available and of type dict
+            if 'config' in seq_conf:
+                sub_seq_conf = seq_conf['config']
+                subsequence = None # seq_conf['config']['sequence']
+                if not isinstance(sub_seq_conf, dict):
+                    raise ValueError(
+                        f"Subsequence config ({name}) must be of type dict,"
+                        f" is {type(sub_seq_conf)}")
+            else:
+                sub_seq_conf = None
+            ### Check if kwargs available and of type dict
+            if 'kwargs' in seq_conf:
+                kwargs = seq_conf['kwargs']
+                if not isinstance(kwargs, dict):
+                    raise ValueError(
+                        f"Kwargs must be of type dict, is {type(kwargs)}")
+            else:
+                kwargs = {}
+            ### Check if sequence is available and of type SequenceBase
+            if 'sequence' in seq_conf:
+                if sub_seq_conf is not None:
+                    warnings.warn(
+                        "If both 'config' and 'sequence' are given, 'sequence' "
+                        "will be used and the seq given in 'config' will be "
+                        "ignored. "
+                        f"{sub_seq_conf['sequence'].__name__} -> "
+                        f"{seq_conf['sequence'].__name__}",
+                    )
+                subsequence = seq_conf['sequence']
+
+            _ = self._add_subsequence(
+                name, subsequence, sub_seq_conf,
+                namespace_to_add_to, **kwargs)
 
     def find_parameters(self, key: str, elements: list = None) -> dict:
         """

--- a/arbok_driver/sub_sequence.py
+++ b/arbok_driver/sub_sequence.py
@@ -36,6 +36,22 @@ class SubSequence(SequenceBase):
         """Returns parent (sub) sequence"""
         return self.find_measurement()
 
+    def add_subsequences_from_dict(
+            self,
+            subsequence_dict: dict,
+            insert_sequences_into_name_space: dict = None) -> None:
+        """
+        Adds subsequences to the sequence from a given dictionary
+
+        Args:
+            subsequence_dict (dict): Dictionary containing the subsequences
+        """
+        super()._add_subsequences_from_dict(
+            default_sequence = SubSequence,
+            subsequence_dict = subsequence_dict,
+            insert_sequences_into_name_space = insert_sequences_into_name_space
+        )
+
     def find_measurement(self):
         """Recursively searches the parent sequence"""
         if self.parent.__class__.__name__ == 'Measurement':
@@ -44,7 +60,7 @@ class SubSequence(SequenceBase):
             return self.parent.find_measurement()
         else:
             raise ValueError(
-                "Parent sequence must be of type Sequence"
+                "Parent sequence must be of type Sequence. "
                 f"Is of type {self.parent.__class__.__name__}")
 
     def get_sequence_path(self, path: str = None) -> str:
@@ -57,32 +73,6 @@ class SubSequence(SequenceBase):
             return f"{self.short_name}__{path}"
         else:
             return self.parent.get_sequence_path(f"{self.short_name}__{path}")
-
-    def _add_subsequence(
-        self,
-        name: str,
-        subsequence: SequenceBase | str,
-        sequence_config: dict = None,
-        insert_sequences_into_name_space: dict = None,
-        **kwargs) -> None:
-        """Adds a subsequence to the sequence"""
-        if subsequence == 'default':
-            subsequence = SubSequence
-        if not issubclass(subsequence, SubSequence):
-            raise TypeError(
-                "Subsequence must be of type SubSequence or str: 'default'")
-        seq_instance = subsequence(
-            parent = self,
-            name = name,
-            sample = self.sample,
-            sequence_config = sequence_config,
-            **kwargs
-            )
-        setattr(self, name, seq_instance)
-        if insert_sequences_into_name_space is not None:
-            name_space = insert_sequences_into_name_space
-            name_space[name] = seq_instance
-        return seq_instance
 
     def __getattr__(self, key: str) -> Any:
         """Returns parameter from self. If parameter is not found in self, 

--- a/arbok_driver/sub_sequence.py
+++ b/arbok_driver/sub_sequence.py
@@ -39,7 +39,7 @@ class SubSequence(SequenceBase):
     def add_subsequences_from_dict(
             self,
             subsequence_dict: dict,
-            insert_sequences_into_name_space: dict = None) -> None:
+            namespace_to_add_to: dict = None) -> None:
         """
         Adds subsequences to the sequence from a given dictionary
 
@@ -49,7 +49,7 @@ class SubSequence(SequenceBase):
         super()._add_subsequences_from_dict(
             default_sequence = SubSequence,
             subsequence_dict = subsequence_dict,
-            insert_sequences_into_name_space = insert_sequences_into_name_space
+            namespace_to_add_to = namespace_to_add_to
         )
 
     def find_measurement(self):


### PR DESCRIPTION
Overworked adding of SubSequences.

Goal:
- Tying configuration and the SubSequence it is configuring strictly together -> more declarative
- simplifying sequence adding process

It is not required to provide a 'sequence' type in the experiment configuration as long as a configuration is given

The changes look bigger than they are since 2 duplicate methods from SubSequence and Measurement have been moved to their parent SequenceBase