### PR TITLE
Simplified adding sub-seq from dict

### DIFF
--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -177,7 +177,7 @@ class SequenceBase(InstrumentModule):
         """
         tr = LeftAligned(draw=draw_style)
         print(tr(self.sub_sequence_dict))
-        
+
     def get_qua_program_as_str(self) -> str:
         """Returns the qua program as str. Will be compiled if it wasnt yet"""
         if self._qua_program_as_str is None:
@@ -475,45 +475,27 @@ class SequenceBase(InstrumentModule):
     def _add_subsequence(
         self,
         name: str,
-        subsequence: 'SequenceBase' = None,
         sequence_config: dict = None,
         namespace_to_add_to: dict = None,
         **kwargs
-        ) -> None:
+        ) -> 'SequenceBase':
         """
         Adds a subsequence to the sequence
         
         Args:
             name (str): Name of the subsequence
-            subsequence (SubSequence): Subsequence to be added
             sequence_config (dict): Config containing all measurement params
             namespace_to_add_to (dict): Name space to insert the
                 subsequence into (e.g locals(), globals()) defaults to None
         """
-        given_subsequence = subsequence
-        if subsequence is None:
-            if sequence_config is None:
-                raise ValueError(
-                    "Neither a subsequence nor a sequence_config was given. "
-                    )
-            try:
-                subsequence = sequence_config['sequence']
-            except KeyError as exc:
-                raise KeyError(
-                    f"The given config for {self.name} does not contain a "
-                    "'sequence' key with a subsequence type to configure for."
-                    ) from exc
-        else:
-            if given_subsequence is not None:
-                if sequence_config is not None and 'sequence' in sequence_config:
-                    warnings.warn(
-                        "Deprecation Warning: sequence types should not be given as "
-                        "arg to 'add_subsequence'. Should be ONLY given in config. "
-                        f"{sequence_config['sequence'].__name__} -> "
-                        f"{subsequence.__name__}",
-                        category = DeprecationWarning
-                        )
-                subsequence = given_subsequence
+        try:
+            subsequence = sequence_config['sequence']
+        except KeyError as exc:
+            raise KeyError(
+                f"The given config for {self.name} does not contain a "
+                "'sequence' key with a subsequence type to configure for."
+                ) from exc
+
         if not issubclass(subsequence, SequenceBase):
             raise TypeError(
                 "Subsequence must be of type SubSequence")
@@ -557,10 +539,13 @@ class SequenceBase(InstrumentModule):
             ### Check whether a subsequence is configured or empty 
             if all(k not in seq_conf.keys() for k in ['sequence', 'config']):
                 ### If empty SubSequence, create one deeper nesting layer
+                sequence_config = {
+                    'sequence': default_sequence,
+                    'parameters': {},
+                    }
                 seq_instance = self._add_subsequence(
                     name = name,
-                    subsequence = default_sequence,
-                    sequence_config = None,
+                    sequence_config = sequence_config,
                     namespace_to_add_to = namespace_to_add_to
                     )
                 seq_instance.add_subsequences_from_dict(
@@ -570,44 +555,47 @@ class SequenceBase(InstrumentModule):
                     name, seq_conf, namespace_to_add_to)
 
     def _prepare_adding_subsequence(
-            self,
-            name: str,
-            seq_conf: dict,
-            namespace_to_add_to: dict = None
-            ) -> None:
-            ### Check if config available and of type dict
-            if 'config' in seq_conf:
+        self,
+        name: str,
+        seq_conf: dict,
+        namespace_to_add_to: dict = None
+        ) -> None:
+        ### Check if config available and of type dict
+        sub_seq_conf = {'parameters': {}}
+        if 'config' in seq_conf:
+            if not isinstance(sub_seq_conf, dict):
+                raise ValueError(
+                    f"Subsequence config ({name}) must be of type dict,"
+                    f" is {type(sub_seq_conf)}")
+            if 'parameters' in seq_conf['config']:
                 sub_seq_conf = seq_conf['config']
-                subsequence = None # seq_conf['config']['sequence']
-                if not isinstance(sub_seq_conf, dict):
-                    raise ValueError(
-                        f"Subsequence config ({name}) must be of type dict,"
-                        f" is {type(sub_seq_conf)}")
             else:
-                sub_seq_conf = None
-            ### Check if kwargs available and of type dict
-            if 'kwargs' in seq_conf:
-                kwargs = seq_conf['kwargs']
-                if not isinstance(kwargs, dict):
-                    raise ValueError(
-                        f"Kwargs must be of type dict, is {type(kwargs)}")
-            else:
-                kwargs = {}
-            ### Check if sequence is available and of type SequenceBase
-            if 'sequence' in seq_conf:
-                if sub_seq_conf is not None:
-                    warnings.warn(
-                        "If both 'config' and 'sequence' are given, 'sequence' "
-                        "will be used and the seq given in 'config' will be "
-                        "ignored. "
-                        f"{sub_seq_conf['sequence'].__name__} -> "
-                        f"{seq_conf['sequence'].__name__}",
-                    )
-                subsequence = seq_conf['sequence']
-
-            _ = self._add_subsequence(
-                name, subsequence, sub_seq_conf,
-                namespace_to_add_to, **kwargs)
+                sub_seq_conf = {'parameters': seq_conf['config']}
+        ### Check if kwargs available and of type dict
+        if 'kwargs' in seq_conf:
+            kwargs = seq_conf['kwargs']
+            if not isinstance(kwargs, dict):
+                raise ValueError(
+                    f"Kwargs must be of type dict, is {type(kwargs)}")
+        else:
+            kwargs = {}
+        ### Check if sequence is available and of type SequenceBase
+        if 'sequence' in seq_conf:
+            if 'sequence' in sub_seq_conf:
+                warnings.warn(
+                    "If both 'config' and 'sequence' are given, 'sequence' "
+                    "will be used and the seq given in 'config' will be "
+                    "ignored. "
+                    f"{sub_seq_conf['sequence'].__name__} -> "
+                    f"{seq_conf['sequence'].__name__}",
+                )
+            sub_seq_conf['sequence'] = seq_conf['sequence']
+        _ = self._add_subsequence(
+            name = name,
+            sequence_config = sub_seq_conf,
+            namespace_to_add_to = namespace_to_add_to,
+            **kwargs
+            )
 
     def find_parameters(self, key: str, elements: list = None) -> dict:
         """


### PR DESCRIPTION
Simplified the `SequenceBase.add_subsequence`

- Removed the 'subsequence' argument. Type of sequence MUST now be given in the config
- Adding subsequences using the mentioned method has bee updated. If 'type' AND 'config' are given a warning will be printed.

This implementation should be backwards compatible