### PR TITLE
Added error if runner is generated in measurement without name

### DIFF
--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -631,6 +631,9 @@ class Measurement(SequenceBase):
             qc_measurement (qc.dataset.Measurement): Measurement instance
         """
         if measurement_name is None:
+            if self.qc_measurement_name is None:
+                raise ValueError(
+                    "No measurement name given and no default set")
             measurement_name = self.qc_measurement_name
         self.qc_measurement = qc.dataset.Measurement(
             exp = self.qc_experiment, name = measurement_name)


### PR DESCRIPTION
Added error to catch un-named measurement runs