### PR TITLE
Move hardware sync to measurement

### DIFF
--- a/arbok_driver/arbok_driver.py
+++ b/arbok_driver/arbok_driver.py
@@ -42,7 +42,7 @@ class ArbokDriver(qc.Instrument):
         self.qm_job = None
         self.result_handles = None
         self.no_pause = False
-        self.is_dummy = False
+        self.is_mock = False
         self._sequences = []
         self.add_parameter('iteration', get_cmd = None, set_cmd =None)
 

--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -710,7 +710,7 @@ class Measurement(SequenceBase):
             progress_bar (tuple): Tuple containing the progress bar and the
                 total number of results
         """
-        bar_title2 = "[cyan]Batch progress "
+        bar_title2 = "[cyan]Batch progress\n"
         batch_count = 0
         time_per_shot = 0
         shot_timing = "Calculate timing...\n"


### PR DESCRIPTION
Moved the hardware synchronisation from `GettableParameter` to 'Measurement'.

- This simplifies the GettbleParameter and avoids duplication of logic and communication in case multiple GettbleParameters are present.

- Mock measurement are easier to manage in Measurement