### PR TITLE
Add error msg if scale not given

### DIFF
--- a/arbok_driver/sequence_parameter.py
+++ b/arbok_driver/sequence_parameter.py
@@ -26,7 +26,7 @@ class SequenceParameter(Parameter):
     qua_var = None
     value = None
     can_be_parameterized = False
-    scale = None
+    scale = 1
 
     def __init__(self, *args, var_type = None, element = None, **kwargs):
         """

--- a/arbok_driver/sweep.py
+++ b/arbok_driver/sweep.py
@@ -136,6 +136,13 @@ class Sweep:
                 value = self.config[parameter]
                 setpoints = parameter.convert_to_real_units(self.config[parameter])
                 if isinstance(value, (list, np.ndarray)):
+                    if parameter.scale is None:
+                        raise ValueError(
+                            f"Parameter scale of '{parameter.full_name}' is None."
+                            " Must be set for sweep arrays. Check the type of"
+                            " the parameter in the config file. If it does not"
+                            " have a type, set the scale manually."
+                            )
                     parameter.set(setpoints)
                     self._config_to_register[parameter] = setpoints*parameter.scale
                 elif isinstance(value, int):


### PR DESCRIPTION
Adding error message if the scale of a `SequenceParameter` is not configured correctly.

Also changed default scale for `SequenceParameter` to 1