### PR TITLE
Rename sequences in driver to measurement

### DIFF
--- a/arbok_driver/arbok_driver.py
+++ b/arbok_driver/arbok_driver.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Union
 
 import numpy as np
 
@@ -43,20 +42,22 @@ class ArbokDriver(qc.Instrument):
         self.result_handles = None
         self.no_pause = False
         self.is_mock = False
-        self._sequences = []
+        self._measurements = []
         self.add_parameter('iteration', get_cmd = None, set_cmd =None)
 
     @property
-    def sequences(self) -> list:
-        """Sequences to be run within program uploaded to the OPX"""
-        return self._sequences
+    def measurements(self) -> list:
+        """Measurements to be run within program uploaded to the OPX"""
+        return self._measurements
 
-    def reset_sequences(self) -> None:
+    def reset_measurements(self) -> None:
         """
-        Resets all sequences in the program
-        TODO: delete instances of those sequences
+        Resets all measurements in the program
+        TODO: delete instances of those measurements
         """
-        self._sequences = []
+        for measurement in self._measurements:
+            del measurement
+        self._measurements = []
         self.submodules = {}
 
     def connect_opx(
@@ -106,16 +107,16 @@ class ArbokDriver(qc.Instrument):
             self.qmm.close_all_quantum_machines()
         self.connect_opx(host_ip, qm_config, reconnect = True)
 
-    def add_sequence(self, new_sequence: SequenceBase):
+    def add_measurement(self, new_measurement: Measurement):
         """
-        Adds a class which inherits `SequenceBase` to the program and adds it
+        Adds a class which inherits `Measurement` to the program and adds it
         as a QCoDeS sub-module
         
         Args:
-            new_sequence (SequenceBase): The instance which inherits
-            SequenceBase to be added
+            new_measurement (Measurement): The instance which inherits
+            Measurement to be added
         """
-        self._sequences.append(new_sequence)
+        self._measurements.append(new_measurement)
 
     def run(self, qua_program, **kwargs):
         """

--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -48,7 +48,7 @@ class Measurement(SequenceBase):
         self.measurement = self
         self._init_vars()
         self._reset_sweeps_setpoints()
-        parent.add_sequence(self)
+        parent.add_measurement(self)
 
         self._is_mock = False
         self._sweep_dims = None

--- a/arbok_driver/sequence_parameter.py
+++ b/arbok_driver/sequence_parameter.py
@@ -37,7 +37,12 @@ class SequenceParameter(Parameter):
             config_name (str): Name of the parameter in the sequence config dict
                 essentially name without the element
         """
-        super().__init__(*args, **kwargs)
+        try:
+            super().__init__(*args, **kwargs)
+        except Exception as e:
+            raise ValueError(
+                f"Error initializing SequenceParameter: {kwargs['name']}: {e}"
+                ) from e
         self.element = element
         if var_type is not None:
             self.var_type = var_type

--- a/arbok_driver/sweep.py
+++ b/arbok_driver/sweep.py
@@ -164,19 +164,21 @@ class Sweep:
         """
         Validates equal sizes of input arrays in three steps:
             1) Checks if all parameters are SequenceParameter/Parameter
-            2) Checks if all sweep setpoint arrays have same lengths
-            3) Checks if all input streams have the same dimension
+            2) Checks if var_type is int, bool or qua.fixed
+            3) Checks if all sweep setpoint arrays have same lengths
+            4) Checks if all input streams have the same dimension
         """
         self._config = self._convert_str_keys_to_param(self._config)
-        param_types_valid = []
         for param in self.config.keys():
-            param_types_valid.append(
-             isinstance(param,(SequenceParameter, Parameter))
-            )
-        if not all(param_types_valid):
-            raise TypeError(
-        "All given parameter must be of SequenceParameter or Parameter"
-        )
+            if not isinstance(param, (SequenceParameter, Parameter)):
+                raise TypeError(
+                    f"Key {param} in sweep config must be of type "
+                    "SequenceParameter or Parameter")
+            if not param.var_type in (int, bool, qua.fixed):
+                raise TypeError(
+                    f"Key {param.full_name} in sweep config must have a var_type"
+                    f" of int, bool, or qua.fixed. Is: {param.var_type}."
+                )
         param_arrays = []
         param_streams = []
         for values in self._config.values():

--- a/arbok_driver/tests/conftest.py
+++ b/arbok_driver/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest 
 
-from arbok_driver import ArbokDriver, Device, SubSequence, Sequence
+from arbok_driver import ArbokDriver, Device, SubSequence, Measurement, parameter_types
 from arbok_driver.tests.dummy_opx_config import dummy_qua_config
 
 opx_scale = 2
@@ -19,45 +19,49 @@ divider_config = {
 @pytest.fixture
 def dummy_device():
     """Returns dummy device instance"""
-    return Device('dummy_device', dummy_qua_config, divider_config)
+    return Device(
+        name = 'dummy_device',
+        opx_config = dummy_qua_config,
+        divider_config = divider_config,
+    )
 
 @pytest.fixture
 def arbok_driver(dummy_device):
     """Returns ArbokDriver instance"""
-    driver = ArbokDriver('arbok_driver', dummy_device)
+    driver = ArbokDriver(name = 'arbok_driver', device = dummy_device)
     yield driver
     driver.__del__()
     del driver
 
 @pytest.fixture
-def dummy_sequence(arbok_driver, dummy_device):
-    """Returns dummy sequence instance"""
-    sequence = Sequence(arbok_driver, 'dummy_sequence', dummy_device)
-    return sequence
-    sequence.__del__()
-    del sequence
+def dummy_measurement(arbok_driver, dummy_device):
+    """Returns dummy measurement instance"""
+    measurement = Measurement(arbok_driver, 'dummy_measurement', dummy_device)
+    yield measurement
+    measurement.__del__()
+    del measurement
 
 @pytest.fixture
-def sub_sequence_1(dummy_sequence, dummy_device):
+def sub_sequence_1(dummy_measurement, dummy_device):
     """Returns dummy subsequence with a few parameters"""
     config_1 = {
-        'par1': {'unit': 'cycles', 'value': int(1)},
-        'par2': {'unit': 'cycles', 'value': int(10)},
-        'par3': {'unit': 'cycles', 'value': 1.1},
-        'vHome': {'unit': 'V', 'elements': {'P1': 5, 'J1': 6, }},
+        'par1': {'type': parameter_types.Int, 'value': int(1)},
+        'par2': {'type': parameter_types.Int, 'value': int(10)},
+        'par3': {'type': parameter_types.Voltage, 'value': 1.1},
+        'vHome': {'type': parameter_types.Voltage, 'elements': {'P1': 5, 'J1': 6, }},
     }
-    seq1 = SubSequence(dummy_sequence, 'sub_seq1', dummy_device, config_1)
+    seq1 = SubSequence(dummy_measurement, 'sub_seq1', dummy_device, config_1)
     yield seq1
     #seq1.__del__()
 
 @pytest.fixture
-def sub_sequence_2(dummy_sequence, dummy_device):
+def sub_sequence_2(dummy_measurement, dummy_device):
     """Returns dummy subsequence with a few parameters"""
     config_2 = {
-        'par4': {'unit': 'cycles', 'value': int(2)},
-        'par5': {'unit': 'cycles', 'value': int(3)},
-        'vHome': {'unit': 'V', 'elements': {'P1': 0, 'J1': 7, }},
+        'par4': {'type': parameter_types.Int, 'value': int(2)},
+        'par5': {'type': parameter_types.Int, 'value': int(3)},
+        'vHome': {'type': parameter_types.Voltage, 'elements': {'P1': 0, 'J1': 7, }},
     }
-    seq2 = SubSequence(dummy_sequence, 'sub_seq2', dummy_device, config_2)
+    seq2 = SubSequence(dummy_measurement, 'sub_seq2', dummy_device, config_2)
     yield seq2
     seq2.__del__()

--- a/arbok_driver/tests/sequence_reset_test.py
+++ b/arbok_driver/tests/sequence_reset_test.py
@@ -1,68 +1,68 @@
-#!/usr/bin/env python
-from arbok_driver import ArbokDriver, Sequence, SubSequence
-from arbok_driver.parameter_types import Voltage, Time, String
-import numpy as np
+# #!/usr/bin/env python
+# from arbok_driver import ArbokDriver, Measurement, SubSequence
+# from arbok_driver.parameter_types import Voltage, Time, String
+# import numpy as np
 
-from helpers import qua_program_trim_gen_time, compare_qua_programs
+# from helpers import qua_program_trim_gen_time, compare_qua_programs
 
-from qm import qua
+# from qm import qua
 
-class SquarePulse(SubSequence):
-    """
-    Class containing parameters and sequence for a simple square pulse
-    """
+# class SquarePulse(SubSequence):
+#     """
+#     Class containing parameters and sequence for a simple square pulse
+#     """
 
-    def qua_sequence(self):
-        """Macro that will be played within the qua.program() context"""
-        qua.align()
-        qua.play('ramp'*qua.amp(self.amplitude()), self.element(), duration = self.ramp_time())
-        qua.wait(self.t_square_pulse(), self.element())
-        qua.play('ramp'*qua.amp(-self.amplitude()), self.element(), duration = self.ramp_time())
+#     def qua_sequence(self):
+#         """Macro that will be played within the qua.program() context"""
+#         qua.align()
+#         qua.play('ramp'*qua.amp(self.amplitude()), self.element(), duration = self.ramp_time())
+#         qua.wait(self.t_square_pulse(), self.element())
+#         qua.play('ramp'*qua.amp(-self.amplitude()), self.element(), duration = self.ramp_time())
 
-square_conf = {
-    'amplitude': {
-        'value': 0.5,
-        'type': Voltage,
-    },
-    't_square_pulse': {
-        'value': 100,
-        'type': Time
-    },
-    'element': {
-        'type': String,
-        'value': 'gate_1',
-        'unit': 'gate label'
-    },
-    'ramp_time': {
-        'value': 20,
-        'type': Time
-    },
-}
+# square_conf = {
+#     'amplitude': {
+#         'value': 0.5,
+#         'type': Voltage,
+#     },
+#     't_square_pulse': {
+#         'value': 100,
+#         'type': Time
+#     },
+#     'element': {
+#         'type': String,
+#         'value': 'gate_1',
+#         'unit': 'gate label'
+#     },
+#     'ramp_time': {
+#         'value': 20,
+#         'type': Time
+#     },
+# }
 
-from arbok_driver import Device
-from arbok_driver.tests.dummy_opx_config import dummy_qua_config, divider_config
+# from arbok_driver import Device
+# from arbok_driver.tests.dummy_opx_config import dummy_qua_config, divider_config
 
-dummy_device = Device('dummy_device', dummy_qua_config, divider_config)
-qm_driver = ArbokDriver('qm_driver', dummy_device)
-dummy_sequence = Sequence(qm_driver, 'dummy_squence', dummy_device)
+# dummy_device = Device('dummy_device', dummy_qua_config, divider_config)
+# qm_driver = ArbokDriver('qm_driver', dummy_device)
+# dummy_measurement = Measurement(qm_driver, 'dummy_measurement', dummy_device)
 
-square_pulse = SquarePulse(dummy_sequence, 'square_pulse', dummy_device, square_conf)
+# square_pulse = SquarePulse(dummy_measurement, 'square_pulse', dummy_device, square_conf)
 
-dummy_sequence.set_sweeps(
-    {
-        square_pulse.amplitude: np.linspace(0.1, 1, 5)
-    }
-)
+# dummy_measurement.set_sweeps(
+#     {
+#         square_pulse.amplitude: np.linspace(0.1, 1, 5)
+#     }
+# )
 
-# dummy_sequence.reset()
-qua_program = dummy_sequence.get_qua_program_as_str()
-qp1 = qua_program_trim_gen_time(qua_program)
+# # dummy_measurement.reset()
+# qua_program = dummy_measurement.get_qua_program_as_str()
+# qp1 = qua_program_trim_gen_time(qua_program)
 
-dummy_sequence.reset()
+# dummy_measurement.reset()
 
-qua_program2 = dummy_sequence.get_qua_program_as_str()
-qp2 = qua_program_trim_gen_time(qua_program2)
+# qua_program2 = dummy_measurement.get_qua_program_as_str()
+# qp2 = qua_program_trim_gen_time(qua_program2)
 
-line_differences = compare_qua_programs(qp1, qp2)
-if len(line_differences):
-    raise Exception("Programes should have been identical, but weren't")
+# line_differences = compare_qua_programs(qp1, qp2)
+# if len(line_differences):
+#     raise Exception("Programes should have been identical, but weren't")

--- a/arbok_driver/tests/test_arbok_driver.py
+++ b/arbok_driver/tests/test_arbok_driver.py
@@ -1,20 +1,20 @@
 """Module testing the Program class"""
 import pytest
-from arbok_driver import Sequence, ArbokDriver, Device
+from arbok_driver import Measurement, ArbokDriver, Device
 
 def test_arbok_driver_init(arbok_driver)-> None:
     """Tests if arbok_driver is correctly initialized"""
     assert arbok_driver.name == 'arbok_driver'
     assert arbok_driver.device.name == 'dummy_device'
-    assert arbok_driver.sequences == []
+    assert arbok_driver.measurements == []
 
-def test_arbok_driver_adding_sequence(arbok_driver, dummy_device)-> None:
-    """Tests if sequence is correctly added to arbok_driver"""
-    seq = Sequence(arbok_driver, 'dummy_sequence', dummy_device)
-    assert len(arbok_driver.sequences) == 1
-    assert arbok_driver.sequences[0] == seq
+def test_arbok_driver_adding_measurement(arbok_driver, dummy_device)-> None:
+    """Tests if measurement is correctly added to arbok_driver"""
+    meas = Measurement(arbok_driver, 'dummy_measurement', dummy_device)
+    assert len(arbok_driver.measurements) == 1
+    assert arbok_driver.measurements[0] == meas
     assert len(arbok_driver.submodules) == 1
 
-    arbok_driver.reset_sequences()
-    assert len(arbok_driver.sequences) == 0
+    arbok_driver.reset_measurements()
+    assert len(arbok_driver.measurements) == 0
     assert len(arbok_driver.submodules) == 0

--- a/arbok_driver/tests/test_measurement_sweep.py
+++ b/arbok_driver/tests/test_measurement_sweep.py
@@ -1,72 +1,72 @@
-#!/usr/bin/env python
-import os
-import tempfile
+# #!/usr/bin/env python
+# import os
+# import tempfile
 
-from arbok_driver import ArbokDriver, Device, ReadSequence
-from arbok_driver.measurement import Measurement
-from types import SimpleNamespace
+# from arbok_driver import ArbokDriver, Device, ReadSequence
+# from arbok_driver.measurement import Measurement
+# from types import SimpleNamespace
 
-from all_the_qua import AllTheQua
-from arbok_driver.parameter_types import Voltage
-import qcodes as qc
-from qm_config.opx1000 import config
+# from all_the_qua import AllTheQua
+# from arbok_driver.parameter_types import Voltage
+# import qcodes as qc
+# from qm_config.opx1000 import config
 
-# get some parameters which we can sweep
-sequence_config = {
-    'parameters': {
-        'v_set_home': {
-            'type': Voltage,
-            'elements': { 'output': 0, 'loopback': 0 }
-        },
-    },
-}
+# # get some parameters which we can sweep
+# sequence_config = {
+#     'parameters': {
+#         'v_set_home': {
+#             'type': Voltage,
+#             'elements': { 'output': 0, 'loopback': 0 }
+#         },
+#     },
+# }
 
-device = SimpleNamespace(**{'elements' : [ 'output', 'loopback' ], 'divider_config' : {} })
-device.reload_master_config = lambda: None  # Method that does nothing but pass
-device.config = config
-arbok_driver = ArbokDriver('arbok_driver', device)
+# device = SimpleNamespace(**{'elements' : [ 'output', 'loopback' ], 'divider_config' : {} })
+# device.reload_master_config = lambda: None  # Method that does nothing but pass
+# device.config = config
+# arbok_driver = ArbokDriver('arbok_driver', device)
 
-measurement = Measurement(
-    parent = arbok_driver,
-    name = 'measurement_name',
-    device = device,
-    sequence_config = sequence_config
-)
-atq = AllTheQua(measurement, 'atq', device)
+# measurement = Measurement(
+#     parent = arbok_driver,
+#     name = 'measurement_name',
+#     device = device,
+#     sequence_config = sequence_config
+# )
+# atq = AllTheQua(measurement, 'atq', device)
 
-measurement.qc_measurement_name = 'sweep_measurement'
-measurement.qc_experiment = qc.dataset.load_or_create_experiment('experiment.name', 'device.name')
+# measurement.qc_measurement_name = 'sweep_measurement'
+# measurement.qc_experiment = qc.dataset.load_or_create_experiment('experiment.name', 'device.name')
 
-import numpy as np
-v_start = 0.1
-v_range = np.linspace(-v_start, v_start, 100)
-v_arr = np.array([0, 1, 10, 100], dtype=float)
+# import numpy as np
+# v_start = 0.1
+# v_range = np.linspace(-v_start, v_start, 100)
+# v_arr = np.array([0, 1, 10, 100], dtype=float)
 
-# sweeps = [{'v_set_home_P1': v_range, 'snake': True},
-#         {'v_set_home_J1': v_arr},
-#         {'v_set_home_P2': 32, 'snake': False},
+# # sweeps = [{'v_set_home_P1': v_range, 'snake': True},
+# #         {'v_set_home_J1': v_arr},
+# #         {'v_set_home_P2': 32, 'snake': False},
+# #         ]
+# sweeps = [
+#     {'v_set_home_output': v_range, 'snake': False},
 #         ]
-sweeps = [
-    {'v_set_home_output': v_range, 'snake': False},
-        ]
 
-measurement.set_sweeps(*sweeps)
-# measurement.register_gettables(keywords=[('atq_stream')])
+# measurement.set_sweeps(*sweeps)
+# # measurement.register_gettables(keywords=[('atq_stream')])
 
-tmp_dir = tempfile.gettempdir()
-file_path = os.path.join(tmp_dir, "arbok_test", "sweep_param_test.qua")
-os.makedirs(os.path.dirname(file_path), exist_ok=True)
+# tmp_dir = tempfile.gettempdir()
+# file_path = os.path.join(tmp_dir, "arbok_test", "sweep_param_test.qua")
+# os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
-measurement.print_qua_program_to_file(file_path)
+# measurement.print_qua_program_to_file(file_path)
 
-sweep_list_arg = [{arbok_driver.iteration: np.arange(1)}]
-run_loop = measurement.get_measurement_loop_function(sweep_list_arg)
+# sweep_list_arg = [{arbok_driver.iteration: np.arange(1)}]
+# run_loop = measurement.get_measurement_loop_function(sweep_list_arg)
 
-# arbok_driver.connect_opx(host_ip = '192.168.88.254', port = 9510, log_level = 'DEBUG')
-# measurement.compile_qua_and_run()
+# # arbok_driver.connect_opx(host_ip = '192.168.88.254', port = 9510, log_level = 'DEBUG')
+# # measurement.compile_qua_and_run()
 
-# try:
-#     dataset = run_loop()
-# except KeyboardInterrupt:
-#     print('Dumping execution report:')
-#     arbok_driver.qm_job.execution_report()
+# # try:
+# #     dataset = run_loop()
+# # except KeyboardInterrupt:
+# #     print('Dumping execution report:')
+# #     arbok_driver.qm_job.execution_report()

--- a/arbok_driver/tests/test_measurement_sweep_parametrised_snake.py
+++ b/arbok_driver/tests/test_measurement_sweep_parametrised_snake.py
@@ -1,77 +1,77 @@
-#!/usr/bin/env python
-import os
-import tempfile
+# #!/usr/bin/env python
+# import os
+# import tempfile
 
-from arbok_driver import ArbokDriver, Device, ReadSequence
-from arbok_driver.measurement import Measurement
-from types import SimpleNamespace
+# from arbok_driver import ArbokDriver, Device, ReadSequence
+# from arbok_driver.measurement import Measurement
+# from types import SimpleNamespace
 
-from all_the_qua import AllTheQua
-from arbok_driver.parameter_types import Voltage
-import qcodes as qc
-from qm_config.opx1000 import config
+# from all_the_qua import AllTheQua
+# from arbok_driver.parameter_types import Voltage
+# import qcodes as qc
+# from qm_config.opx1000 import config
 
-# get some parameters which we can sweep
-measurement_config = {
-    'parameters': {
-        'v_set_home': {
-            'type': Voltage,
-            'elements': { 'element_a': 0, 'element_b': 0, 'element_c': 0, 'element_d': 0 }
-        },
-    },
-}
+# # get some parameters which we can sweep
+# measurement_config = {
+#     'parameters': {
+#         'v_set_home': {
+#             'type': Voltage,
+#             'elements': { 'element_a': 0, 'element_b': 0, 'element_c': 0, 'element_d': 0 }
+#         },
+#     },
+# }
 
-device = SimpleNamespace(**{'elements' : [ 'element_a', 'element_b', 'element_c', 'element_d' ], 'divider_config' : {} })
-device.config = config
-arbok_driver = ArbokDriver('arbok_driver', device)
+# device = SimpleNamespace(**{'elements' : [ 'element_a', 'element_b', 'element_c', 'element_d' ], 'divider_config' : {} })
+# device.config = config
+# arbok_driver = ArbokDriver('arbok_driver', device)
 
-measurement = Measurement(
-    parent = arbok_driver,
-    name = 'measurement_name',
-    device = device,
-    sequence_config = measurement_config
-)
+# measurement = Measurement(
+#     parent = arbok_driver,
+#     name = 'measurement_name',
+#     device = device,
+#     sequence_config = measurement_config
+# )
 
-from arbok_driver.tests.var_readout import VarReadout
-available_abstract_readouts = {
-    'var_readout': VarReadout
-}
-from arbok_driver.tests.var_readout_config import var_readout_config
-atq = AllTheQua(measurement, 'atq', device, var_readout_config, available_abstract_readouts = available_abstract_readouts)
+# from arbok_driver.tests.var_readout import VarReadout
+# available_abstract_readouts = {
+#     'var_readout': VarReadout
+# }
+# from arbok_driver.tests.var_readout_config import var_readout_config
+# atq = AllTheQua(measurement, 'atq', device, var_readout_config, available_abstract_readouts = available_abstract_readouts)
 
-measurement.qc_measurement_name = 'sweep_measurement'
-measurement.qc_experiment = qc.dataset.load_or_create_experiment('experiment.name', 'device.name')
+# measurement.qc_measurement_name = 'sweep_measurement'
+# measurement.qc_experiment = qc.dataset.load_or_create_experiment('experiment.name', 'device.name')
 
-import numpy as np
-v_start = 0.1
-v_range_a = np.linspace(-v_start, v_start, 10)
-v_range_b = np.linspace(-v_start, v_start, 20)
-v_range_c = np.linspace(-v_start, v_start, 30)
-v_arr = np.array([0, 1, 10, 100], dtype=float)
+# import numpy as np
+# v_start = 0.1
+# v_range_a = np.linspace(-v_start, v_start, 10)
+# v_range_b = np.linspace(-v_start, v_start, 20)
+# v_range_c = np.linspace(-v_start, v_start, 30)
+# v_arr = np.array([0, 1, 10, 100], dtype=float)
 
-sweeps = [
-    {'v_set_home_element_a': v_range_a},
-    {'v_set_home_element_b': v_range_b},
-    {'v_set_home_element_c': v_range_c,
-     'v_set_home_element_d': v_range_c, 'snake': True},
-        ]
+# sweeps = [
+#     {'v_set_home_element_a': v_range_a},
+#     {'v_set_home_element_b': v_range_b},
+#     {'v_set_home_element_c': v_range_c,
+#      'v_set_home_element_d': v_range_c, 'snake': True},
+#         ]
 
-measurement.set_sweeps(*sweeps)
-measurement.register_gettables(atq.gettables[0])
+# measurement.set_sweeps(*sweeps)
+# measurement.register_gettables(atq.gettables[0])
 
-tmp_dir = tempfile.gettempdir()
-file_path = os.path.join(tmp_dir, "arbok_test", "sweep_param_snake_test.py")
-os.makedirs(os.path.dirname(file_path), exist_ok=True)
-measurement.print_qua_program_to_file(file_path)
+# tmp_dir = tempfile.gettempdir()
+# file_path = os.path.join(tmp_dir, "arbok_test", "sweep_param_snake_test.py")
+# os.makedirs(os.path.dirname(file_path), exist_ok=True)
+# measurement.print_qua_program_to_file(file_path)
 
-sweep_list_arg = [{arbok_driver.iteration: np.arange(1)}]
-run_loop = measurement.get_measurement_loop_function(sweep_list_arg)
+# sweep_list_arg = [{arbok_driver.iteration: np.arange(1)}]
+# run_loop = measurement.get_measurement_loop_function(sweep_list_arg)
 
-arbok_driver.connect_opx(host_ip = '192.168.88.254', port = 9510, log_level = 'DEBUG')
-measurement.compile_qua_and_run()
+# arbok_driver.connect_opx(host_ip = '192.168.88.254', port = 9510, log_level = 'DEBUG')
+# measurement.compile_qua_and_run()
 
-try:
-    dataset = run_loop()
-except KeyboardInterrupt:
-    print('Dumping execution report:')
-    arbok_driver.qm_job.execution_report()
+# try:
+#     dataset = run_loop()
+# except KeyboardInterrupt:
+#     print('Dumping execution report:')
+#     arbok_driver.qm_job.execution_report()

--- a/arbok_driver/tests/test_sequence.py
+++ b/arbok_driver/tests/test_sequence.py
@@ -3,16 +3,16 @@ import numpy as np
 from qm import generate_qua_script
 from sklearn import dummy
 
-from arbok_driver import Sequence, SubSequence
+from arbok_driver import Measurement, SubSequence
 from arbok_driver.tests.helpers import set_sweeps_args
 
 def test_sequence_init(arbok_driver, dummy_device) -> None:
     """Tests if sequence is correctly initialized"""
-    seq = Sequence(arbok_driver, 'dummy_sequence', dummy_device)
-    assert seq.name == f'{arbok_driver.name}_dummy_sequence'
+    seq = Measurement(arbok_driver, 'dummy_measurement', dummy_device)
+    assert seq.name == f'{arbok_driver.name}_dummy_measurement'
 
 def test_sequence_sub_sequence_addition(
-        dummy_sequence, dummy_device) -> None:
+        dummy_measurement, dummy_device) -> None:
     """Tests if subsequence is correctly added to sequence"""
     config_1 = {
         'par1': {'unit': 'cycles', 'value': int(1)},
@@ -20,30 +20,30 @@ def test_sequence_sub_sequence_addition(
         'par3': {'unit': 'cycles', 'value': 1.1},
         'vHome': {'unit': 'V', 'elements': {'P1': 5, 'J1': 6, }},
     }
-    seq1 = SubSequence(dummy_sequence, 'seq1', dummy_device, config_1)
-    assert len(dummy_sequence.submodules) == 1
-    assert len(dummy_sequence.sub_sequences) == 1
-    assert dummy_sequence.sub_sequences[0] == seq1
-    assert hasattr(dummy_sequence, 'seq1')
-    assert dummy_sequence.seq1 == seq1
+    seq1 = SubSequence(dummy_measurement, 'seq1', dummy_device, config_1)
+    assert len(dummy_measurement.submodules) == 1
+    assert len(dummy_measurement.sub_sequences) == 1
+    assert dummy_measurement.sub_sequences[0] == seq1
+    assert hasattr(dummy_measurement, 'seq1')
+    assert dummy_measurement.seq1 == seq1
 
-def test_set_sweeps(sub_sequence_1, dummy_sequence) -> None:
+def test_set_sweeps(sub_sequence_1, dummy_measurement) -> None:
     """Tests if sweeps are correctly set"""
-    dummy_sequence.set_sweeps({sub_sequence_1.par1: np.arange(10)},
+    dummy_measurement.set_sweeps({sub_sequence_1.par1: np.arange(10)},
                               {sub_sequence_1.par2: np.arange(5)})
-    assert len(dummy_sequence.sweeps) == 2
-    assert dummy_sequence.sweeps[0].length == 10
-    assert dummy_sequence.sweeps[1].length == 5
-    assert len(dummy_sequence.sweeps[0].parameters) == 1
-    assert dummy_sequence.sweep_size == 50
+    assert len(dummy_measurement.sweeps) == 2
+    assert dummy_measurement.sweeps[0].length == 10
+    assert dummy_measurement.sweeps[1].length == 5
+    assert len(dummy_measurement.sweeps[0].parameters) == 1
+    assert dummy_measurement.sweep_size == 50
 
 # def test_qua_program_compilation_w_sweeps(
-#         dummy_sequence) -> None:
+#         dummy_measurement) -> None:
 #     """Tests whether the qua code is compiled correctly"""
-#     print(dummy_sequence.submodules)
-#     dummy_sequence.set_sweeps(*set_sweeps_args(dummy_sequence))
-#     qua_prog_str = dummy_sequence.get_qua_program_as_str()
-#     dummy_sequence.print_qua_program_to_file('test_output.txt')
+#     print(dummy_measurement.submodules)
+#     dummy_measurement.set_sweeps(*set_sweeps_args(dummy_measurement))
+#     qua_prog_str = dummy_measurement.get_qua_program_as_str()
+#     dummy_measurement.print_qua_program_to_file('test_output.txt')
 #     # we expect 8 declares: 2x3(2 per parameter -> sweep_arr + qua_var)
 #     # + 2 as iterators for for loops (per sweep axis)
 #     assert len([m.start() for m in re.finditer('declare', qua_prog_str)]) == 8

--- a/arbok_driver/tests/test_sub_sequence.py
+++ b/arbok_driver/tests/test_sub_sequence.py
@@ -26,11 +26,11 @@ def test_parent_child_sequence_behaviour(
         print(parent_sub_sequence.submodules)
 
 def test_qua_program_compilation_wo_sweeps(
-        dummy_sequence) -> None:
+        dummy_measurement) -> None:
     """Tests if any sub sequence within a sequence that has sweeps compiles 
     correctly to QUA code considering those sweeps """
-    dummy_sequence.set_sweeps(*set_sweeps_args(dummy_sequence))
-    qua_prog_str = dummy_sequence.dummy_parent_sub.get_qua_program_as_str()
+    dummy_measurement.set_sweeps(*set_sweeps_args(dummy_measurement))
+    qua_prog_str = dummy_measurement.dummy_parent_sub.get_qua_program_as_str()
     # we expect 8 declares: 2x3(2 per parameter -> sweep_arr + qua_var) 
     # + 2 as iterators for for loops (per sweep axis)
     assert len([m.start() for m in re.finditer('declare', qua_prog_str)]) == 8
@@ -39,7 +39,7 @@ def test_qua_program_compilation_wo_sweeps(
     # we expect 2 one per sweep axis
     assert len([m.start() for m in re.finditer('for_', qua_prog_str)]) == 2
     #breakpoint()
-    qua_prog_str = dummy_sequence.dummy_parent_sub.sub_seq1.get_qua_program_as_str()
+    qua_prog_str = dummy_measurement.dummy_parent_sub.sub_seq1.get_qua_program_as_str()
     assert len([m.start() for m in re.finditer('declare', qua_prog_str)]) == 8
     assert len([m.start() for m in re.finditer('assign', qua_prog_str)]) == 3
     assert len([m.start() for m in re.finditer('for_', qua_prog_str)]) == 2
@@ -59,10 +59,10 @@ def test_add_qc_params_from_config(sub_sequence_1) -> None:
             'par69': {'unit': 'cycles', 'toast': int(8)},
             })
 
-def test_find_measurement(mock_program, dummy_sequence) -> None:
+def test_find_measurement(mock_program, dummy_measurement) -> None:
     """Tests if parent sequence is found from sub sequences"""
-    mock_program.add_sequence(dummy_sequence)
-    parent = mock_program.dummy_sequence.measurement
-    assert parent == mock_program.dummy_sequence
-    parent = mock_program.dummy_sequence.dummy_parent_sub.measurement
-    assert parent == mock_program.dummy_sequence
+    mock_program.add_measurement(dummy_measurement)
+    parent = mock_program.dummy_measurement.measurement
+    assert parent == mock_program.dummy_measurement
+    parent = mock_program.dummy_measurement.dummy_parent_sub.measurement
+    assert parent == mock_program.dummy_measurement


### PR DESCRIPTION
Renamed method and property of arbok_driver still referencing the old naming (sequence instead of measurement).

Some minor additions:
- worked on some tests
- added more clear error messages