### PR TITLE
Remove parameter config without type

### DIFF
--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -492,7 +492,7 @@ class Measurement(SequenceBase):
         for i, (_, gettable) in enumerate(self.gettables.items()):
             gettable.setpoints = self._setpoints_for_gettables
             gettable.configure_from_measurement()
-            
+
     def _check_given_gettables(self, gettables: dict) -> None:
         """
         Check validity of given gettables
@@ -531,21 +531,21 @@ class Measurement(SequenceBase):
             self._qua_declare_input_stream_type(qua_type)
 
     def _qua_declare_input_stream_type(
-        self, type: int | bool | qua.fixed) -> None:
+        self, qua_type: int | bool | qua.fixed) -> None:
         length = 0
         for param in self.input_stream_parameters:
-            if param.var_type == type:
+            if param.var_type == qua_type:
                 length += 1
                 param.qua_var = qua.declare(param.var_type)
                 param.qua_sweeped = True
         if length > 0:
             input_stream = qua.declare_input_stream(
-                type,
-                name = f"{self.short_name}_{type.__name__}_input_stream",
+                qua_type,
+                name = f"{self.short_name}_{qua_type.__name__}_input_stream",
                 size = length
             )
-            setattr(self, f"_qua_{type.__name__}_input_stream", input_stream)
-            self._input_stream_type_shapes[type.__name__] = length
+            setattr(self, f"_qua_{qua_type.__name__}_input_stream", input_stream)
+            self._input_stream_type_shapes[qua_type.__name__] = length
 
     def get_sequence_path(self):
         """Returns its name since Measurement is the top level"""

--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -401,11 +401,16 @@ class SequenceBase(InstrumentModule):
         Returns:
             dict: Reshaped parameter dict
         """
+        if 'type' not in param_dict and 'parameter_class' not in param_dict:
+            raise KeyError(
+                f"Config for parameter '{param_name}' on '{self.full_name}'"
+                " does not contain a 'type' key."
+                " Please provide a type of the parameter to be added."
+                " Find available ones in arbok_driver/parameter_types.py."
+                " Or use a custom one.")
         if 'type' in param_dict:
             param_dict['parameter_class'] = param_dict['type']
             del param_dict['type']
-        else:
-            param_dict['parameter_class'] = SequenceParameter
         if 'value' in param_dict:
             param_dict['initial_value'] = param_dict['value']
             del param_dict['value']


### PR DESCRIPTION
Removed the ability to configure parameters without specifying a parameter type.
This avoids unexpected behavior of default values.
All default values can be found in the given parameter type inheriting from `SequenceParameter`