### PR TITLE
Fix stepping bug

### DIFF
--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -742,10 +742,10 @@ class Measurement(SequenceBase):
         ### Also check if streams are available
         try:
             is_paused = self.driver.qm_job.is_paused()
-            while batch_count < self.sweep_size: # or not is_paused:
+            while batch_count < self.sweep_size and not is_paused:
                 logging.debug(
-                    "Waiting for buffer to fill (%s/%s), %s",
-                    batch_count, self.sweep_size, self.driver.qm_job.is_paused()
+                    "Waiting for buffer to fill (%s/%s), is paused: %s",
+                    batch_count, self.sweep_size, is_paused
                     )
                 shot_count_result = self.batch_counter.fetch_all()
                 if shot_count_result is not None:

--- a/arbok_driver/measurement_runner.py
+++ b/arbok_driver/measurement_runner.py
@@ -1,4 +1,6 @@
 """Module containing the MeasurementRunner class."""
+from __future__ import annotations
+from typing import TYPE_CHECKING
 import logging
 import copy
 import time
@@ -7,6 +9,9 @@ import warnings
 import numpy as np
 from rich.progress import Progress
 
+if TYPE_CHECKING:
+    from arbok_driver import Measurement
+
 class MeasurementRunner:
     """
     Helper class constructing QCoDeS measurement loops
@@ -14,7 +19,7 @@ class MeasurementRunner:
 
     def __init__(
         self,
-        measurement: 'Measurement',
+        measurement: Measurement,
         sweep_list: list[dict],
         register_all: bool = False
         ):
@@ -102,7 +107,7 @@ class MeasurementRunner:
             ### Program is resumed and all gettables are fetched when ready
             if not self.measurement.driver.is_mock:
                 self.measurement.driver.qm_job.resume()
-            time.sleep(1)
+            time.sleep(0.1)
             logging.debug("Job resumed, Fetching gettables")
             self.measurement.wait_until_result_buffer_full(
                 (self.progress_bars['batch_progress'], self.progress_tracker)


### PR DESCRIPTION
When using step_requirements on a measurement, the shots were not counted correctly anymore due to a reversal of sweeps in a recent update.

Also added some more type annotations