### PR TITLE
Remove recursion

### DIFF
--- a/arbok_driver/experiment.py
+++ b/arbok_driver/experiment.py
@@ -34,7 +34,7 @@ class Experiment(ABC):
         """
         self._name = name
         self.device = device
-        self.configs = copy.deepcopy(device.default_sequence_configs)
+        self.configs: dict = copy.deepcopy(device.default_sequence_configs)
         if configs_to_prepare is not None:
             self._prepare_configs(configs_to_prepare)
 

--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -197,6 +197,8 @@ class Measurement(SequenceBase):
         self.shot_tracker_qua_var = qua.declare(int, value = 0)
         self.shot_tracker_qua_stream = qua.declare_stream()
         self._qua_declare_input_streams()
+        for sub_sequence in self.sub_sequences:
+            sub_sequence.qua_declare()
 
     def qua_before_sweep(self):
         """
@@ -249,11 +251,15 @@ class Measurement(SequenceBase):
         if simulate:
             for qua_var in self.step_requirements:
                 qua.assign(qua_var, True)
+        for sub_sequence in self.sub_sequences:
+            sub_sequence.qua_before_sequence()
 
     def qua_after_sequence(self):
         """
         Qua code to be executed after the measurement loop and the code it contains
         """
+        for sub_sequence in self.sub_sequences:
+            sub_sequence.qua_after_sequence()
         qua.align()
         self.qua_check_step_requirements(self.qua_increment_shot_tracker)
         qua.align()
@@ -277,6 +283,8 @@ class Measurement(SequenceBase):
                     stream.buffer(
                         self._input_stream_type_shapes[var_type]).save_all(
                             stream_name)
+        for sub_sequence in self.sub_sequences:
+            sub_sequence.qua_stream()
 
     def set_sweeps(self, *args) -> None:
         """

--- a/arbok_driver/measurement.py
+++ b/arbok_driver/measurement.py
@@ -374,8 +374,7 @@ class Measurement(SequenceBase):
         """
         ### In the first step all variables of all sub-sequences are declared
         self.qua_declare_sweep_vars()
-        self.recursive_qua_generation(
-            seq_type = 'declare', skip_duplicates = True)
+        self.qua_declare()
 
         ### An infinite loop starting with a pause is defined to sync the
         ### client with the QMs
@@ -390,9 +389,7 @@ class Measurement(SequenceBase):
 
             ### The sub-sequences are run in the order they were added
             ### Before_sweep methods are run before the sweep loop
-            self.recursive_qua_generation(
-                seq_type = 'before_sweep', skip_duplicates = True)
-
+            self.qua_before_sweep()
             ### The sweep loop is defined for each sub-sequence recursively
             ### Reversing the sweeps is necessary to have the outermost sweep
             ### loop first (e.g last element in the list is the innermost sweep)
@@ -400,7 +397,7 @@ class Measurement(SequenceBase):
                 copy.copy(self.sweeps)
                 )
         with qua.stream_processing():
-            self.recursive_qua_generation(seq_type = 'stream')
+            self.qua_stream()
 
     def compile_qua_and_run(self, save_path: str = None) -> None:
         """Compiles the QUA code and runs it"""

--- a/arbok_driver/sequence_base.py
+++ b/arbok_driver/sequence_base.py
@@ -1,5 +1,8 @@
 """ Module containing BaseSequence class """
-
+from __future__ import annotations
+from ast import Sub
+from encodings.punycode import T
+from typing import TYPE_CHECKING
 import copy
 import types
 import warnings
@@ -18,6 +21,9 @@ from qm.simulate.credentials import create_credentials
 from .device import Device
 from .sequence_parameter import SequenceParameter
 from . import utils
+if TYPE_CHECKING:
+    from .measurement import Measurement
+    from .sub_sequence import SubSequence
 
 class SequenceBase(InstrumentModule):
     """
@@ -110,7 +116,7 @@ class SequenceBase(InstrumentModule):
             sub_sequence.qua_stream()
 
     @property
-    def sub_sequences(self) -> list:
+    def sub_sequences(self) -> list[SubSequence]:
         """
         List of `SubSequences`s that build the given sequence
         """
@@ -128,8 +134,6 @@ class SequenceBase(InstrumentModule):
                 sub_dict = sub_sequence.sub_sequence_dict
                 structure_dict[sub_sequence.short_name] = sub_dict[sub_sequence.short_name]
             else:
-                #name = f"{sub_sequence.short_name} [{sub_sequence.__name__}]"
-                #structure_dict[name] = {}
                 structure_dict[sub_sequence.short_name] = {}
         return {self.short_name: structure_dict}
 

--- a/arbok_driver/sub_sequence.py
+++ b/arbok_driver/sub_sequence.py
@@ -40,6 +40,15 @@ class SubSequence(SequenceBase):
         """Returns parent (sub) sequence"""
         return self.find_measurement()
 
+    def qua_sequence(self):
+        print('Checking step requirements:', self.name,  self.check_step_requirements)
+        if self.check_step_requirements:
+            self.measurement.qua_check_step_requirements(
+                super().qua_sequence
+            )
+        else:
+            super().qua_sequence()
+
     def add_subsequences_from_dict(
             self,
             subsequence_dict: dict,


### PR DESCRIPTION
Qua content of sub_sequence has been added in a recursive way until the lowest sub_sequences were reached.

This was simplified by each SequenceBase instance generating qua from its own sub_sequences. Hereby the complexity of the code is reduced.

Further added the option to add kwargs to empty SubSequences as well. This is useful if you want to make step requirements to be considered for SubSequences that are higher in the hierarchy. 