### PR TITLE
Moved native db connection check from runner base to native

### DIFF
--- a/arbok_driver/measurement_runners/measurement_runner_base.py
+++ b/arbok_driver/measurement_runners/measurement_runner_base.py
@@ -28,7 +28,6 @@ class MeasurementRunnerBase(ABC):
         self.measurement = measurement
         self.arbok_driver = measurement.driver
         self.ext_sweep_list = ext_sweep_list
-        self.arbok_driver.check_db_engine_and_bucket_connected()
         self.external_param_values = self._get_external_params(
             self.ext_sweep_list, register_all)
 

--- a/arbok_driver/measurement_runners/native_measurement_runner.py
+++ b/arbok_driver/measurement_runners/native_measurement_runner.py
@@ -41,7 +41,7 @@ class NativeMeasurementRunner(MeasurementRunnerBase):
         self.sql_run: SqlRun | None = None
         self.minio_data_store = None
         self.bucket_entry_name = None
-
+        self.arbok_driver.check_db_engine_and_bucket_connected()
         self.opx_dims, self.opx_coords, self.opx_units = \
             generate_dims_and_coords(self.measurement.sweeps)
 


### PR DESCRIPTION
Moved native db connection check from runner base to native

-> fixes connection error when running in 'qcodes' mode